### PR TITLE
Examples need to specify POST method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,8 @@ Manually: (A fine idea if you're not going to use in programatically in your nod
 Then in your node app:
 
     var request = require('request');
-    request({ uri : 'http://localhost:3030/parseFeed',
+    request({ method : 'POST',
+              uri : 'http://localhost:3030/parseFeed',
               body : { url: 'http://cyber.law.harvard.edu/rss/examples/rss2sample.xml' },
               json : true },
               function (err, response, body){
@@ -47,6 +48,9 @@ Then in your node app:
                   body.articles.forEach(function (article) {
                     console.log('%s - %s', article.pubDate, article.title || article.description.substring(0,50));
                   });
+                }
+                else {
+                  console.log("Either couldn't connect to parserproxy or it failed.");
                 }
               });
 
@@ -63,7 +67,8 @@ Then in your node app:
       // you are going to make one or more requests immediately upon start up.
     
       setTimeout(function(){
-        request({ uri : 'http://localhost:3030/parseFeed',
+        request({ method : 'POST',
+                  uri : 'http://localhost:3030/parseFeed',
                   body : { url: 'http://scripting.com/rss.xml' },
                   json : true },
                   function (err, response, body){

--- a/examples/module.js
+++ b/examples/module.js
@@ -9,7 +9,8 @@ forever.start(parserproxy).on('start', function (process, data){
   // you are going to make one or more requests immediately upon start up.
 
   setTimeout(function(){
-    request({ uri : 'http://localhost:3030/parseFeed',
+    request({ method : 'POST',
+              uri : 'http://localhost:3030/parseFeed',
               body : { url: 'http://cyber.law.harvard.edu/rss/examples/rss2sample.xml' },
               json : true },
               function (err, response, body){
@@ -18,6 +19,9 @@ forever.start(parserproxy).on('start', function (process, data){
                   body.articles.forEach(function (article) {
                     console.log('%s - %s', article.pubDate, article.title || article.description.substring(0,50));
                   });
+                }
+                else {
+                  console.log("Either couldn't connect to parserproxy or it failed.");
                 }
               });
   }, 1000);


### PR DESCRIPTION
Maybe it worked at one point but with with request 2.1.1 you have to specify the POST method or else the server responds with a 501 and the example fails silently. I changed it to make POSTs and added a simple error message so if there's a problem you're not scratching your head wondering if anything happened.
